### PR TITLE
This commit introduces a root package.json to manage the monorepo.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "meeting-room-booking-root",
+  "version": "1.0.0",
+  "description": "Root package for the Meeting Room Booking System monorepo.",
+  "private": true,
+  "scripts": {
+    "start:backend": "cd backend && npm start",
+    "start:frontend": "cd frontend && npm run dev",
+    "start": "concurrently \"npm:start:backend\" \"npm:start:frontend\"",
+    "install:all": "npm install && cd backend && npm install && cd ../frontend && npm install",
+    "test": "cd backend && npm test"
+  },
+  "devDependencies": {
+    "concurrently": "^8.2.0"
+  },
+  "author": "",
+  "license": "ISC"
+}


### PR DESCRIPTION
Adds the `concurrently` library to run both the backend and frontend servers with a single `npm start` command from the root directory.

Includes a helper script `install:all` to install dependencies for all packages, and a root `test` script that runs the backend tests.